### PR TITLE
Add queue caching

### DIFF
--- a/lib/ssh_scan_api/database/sqlite.rb
+++ b/lib/ssh_scan_api/database/sqlite.rb
@@ -49,7 +49,7 @@ module SSHScan
 
       def add_scan(worker_id, uuid, result, socket)
         @database.execute "insert into ssh_scan values ( ? , ? , ? , ? , ? )",
-                    [uuid, socket[:target], socket[:port],
+                    [uuid, socket["target"], socket["port"],
                      result.to_json, worker_id]
       end
 
@@ -79,11 +79,11 @@ module SSHScan
         results = @database.execute(
           "select uuid, result from ssh_scan
           where target like ( ? ) and port like ( ? )",
-          [socket[:target], socket[:port]]
+          [socket["target"], socket["port"]]
         )
         return nil if results == []
-        result[:uuid] = results[result.length()-1][0]
-        result[:start_time] = JSON.parse(results[result.length()-1][1])["start_time"]
+        result["uuid"] = results[result.length()-1][0]
+        result["start_time"] = JSON.parse(results[result.length()-1][1])["start_time"]
         return result
       end
     end

--- a/lib/ssh_scan_api/job_queue.rb
+++ b/lib/ssh_scan_api/job_queue.rb
@@ -1,19 +1,29 @@
+require 'set'
+
 module SSHScan
   class JobQueue
     def initialize
-      @queue = Queue.new
+      @queue = Set.new
     end
 
     # @param [String] a socket we want to scan (Example: "192.168.1.1:22")
     # @return [nil]
     def add(socket)
-      @queue.push(socket)
+      @queue << socket
+    end
+
+    def each
+      @queue.each do |item|
+        yield item
+      end
     end
 
     # @return [String] a socket we want to scan (Example: "192.168.1.1:22")
     def next
       return nil if @queue.empty?
-      @queue.pop
+      next_item = @queue.first
+      @queue.delete(next_item)
+      return next_item
     end
 
     # @return [FixNum] the number of jobs in the JobQueue

--- a/spec/ssh_scan_api/database/sqlite_spec.rb
+++ b/spec/ssh_scan_api/database/sqlite_spec.rb
@@ -165,4 +165,27 @@ describe SSHScan::DB::SQLite do
     temp_file.close
   end
 
+  it "should #fetch_cached_result in database" do
+    worker_id = SecureRandom.uuid
+    uuid1 = SecureRandom.uuid
+    scan_time = Time.now.to_s
+    result1 = {"ip" => "127.0.0.1", "port" => 1337, "foo" => "bar", "biz" => "baz", "start_time" => scan_time}
+    socket = {"target" => "127.0.0.1", "port" => 1337}
+
+    temp_file = Tempfile.new('sqlite_database_file')
+
+    opts = {
+      "file" => temp_file.path
+    }
+
+    sqlite_db = SSHScan::DB::SQLite.from_hash(opts)
+    sqlite_db.add_scan(worker_id, uuid1, result1, socket)
+
+    response = sqlite_db.fetch_cached_result(socket)
+    expect(response["uuid"]).to eql(uuid1)
+    expect(response["start_time"]).to eql(scan_time)
+
+    temp_file.close
+  end
+
 end

--- a/spec/ssh_scan_api/job_queue_spec.rb
+++ b/spec/ssh_scan_api/job_queue_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+require 'ssh_scan_api/job_queue'
+
+describe SSHScan::JobQueue do
+  it "should have zero requests to start with" do
+    job_queue = SSHScan::JobQueue.new
+    expect(job_queue.size).to eql(0)
+  end
+
+  it "should add jobs to the queue" do
+    job_queue = SSHScan::JobQueue.new
+    expect(job_queue.size).to eql(0)
+    job_queue.add("job")
+    expect(job_queue.size).to eql(1)
+  end
+
+  it "should pull jobs to the queue, in the right order" do
+    job_queue = SSHScan::JobQueue.new
+    expect(job_queue.size).to eql(0)
+    job_queue.add("job1")
+    job_queue.add("job2")
+    expect(job_queue.next).to eql("job1")
+    expect(job_queue.next).to eql("job2")
+  end
+
+  it "should be enumerable" do
+    job_queue = SSHScan::JobQueue.new
+    expect(job_queue.size).to eql(0)
+    job_queue.add("job1")
+    job_queue.add("job2")
+    expect(job_queue).to respond_to(:each)
+  end
+end


### PR DESCRIPTION
This is a stop gap to prevent queue spamming and the eventual result of hitting the same target over and over in a very short period of time.

It helps mitigate #27 in the queue, but not after the queue item is consumed by a worker.  This will be completely resolved once we get to queue status (queued, running, completed) being maintained in the DB, which is partially underway in https://github.com/mozilla/ssh_scan_api/pull/2

This also swaps out the pre-existing Ruby Queue implementation with a Set-based queue to make it slightly more usable for managing and checking for pre-existing queue duplicates.