### PR TITLE
Run sinatra in production mode

### DIFF
--- a/lib/ssh_scan_api/api.rb
+++ b/lib/ssh_scan_api/api.rb
@@ -19,6 +19,7 @@ module SSHScan
         opts = YAML.load_file(config_file)
         opts["config_file"] = config_file
         set :db, SSHScan::Database.from_hash(opts)
+        set :environment, :production
       end
     end
 


### PR DESCRIPTION
This is aimed at making Sinatra less chatty and slightly more strict about how it responds to bogus requests or requests that result in stack traces.