### PR TITLE
Moar deployment tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 *.db
 /coverage/
 
+config/api/config.yml
+config/policies/mozilla_modern.yml
+config/worker/config.yml
+
 ## Documentation cache and generated files:
 /.yardoc/
 /_yardoc/

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 # Allow local checkout of ssh_scan repo
-gem 'ssh_scan', :path=>'../ssh_scan'
+#gem 'ssh_scan', :path=>'../ssh_scan'
 
 gem 'coveralls', require: false
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,7 @@
 source "https://rubygems.org"
 
+# Allow local checkout of ssh_scan repo
+gem 'ssh_scan', :path=>'../ssh_scan'
+
 gem 'coveralls', require: false
 gemspec

--- a/ssh_scan_api.gemspec
+++ b/ssh_scan_api.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.description = 'An API for performing SSH scans'
   s.homepage = 'http://rubygems.org/gems/ssh_scan_api'
 
-  s.add_dependency('ssh_scan', '0.0.20')
+  s.add_dependency('ssh_scan', '~> 0.0.20')
   s.add_dependency('mongo')
   s.add_dependency('sqlite3')
   s.add_dependency('sinatra')


### PR DESCRIPTION
Make it so deployments don't require gem releases.

This is mainly for speed and responsiveness if there are issues, eventually when things stablize we can roll back to gem-only releases.