### PR TITLE
Set worker timeout default

### DIFF
--- a/lib/ssh_scan_api/worker.rb
+++ b/lib/ssh_scan_api/worker.rb
@@ -95,6 +95,7 @@ work?worker_id=#{@worker_id}"
       @logger.info("Started job: #{job["uuid"]}")
       scan_engine = SSHScan::ScanEngine.new
       job["fingerprint_database"] = File.join(File.dirname(__FILE__),"../../data/fingerprints.yml")
+      job["timeout"] = 5
       results = scan_engine.scan(job)
       @logger.info("Completed job: #{job["uuid"]}")
       return results


### PR DESCRIPTION
This was causing mass test scans to hang up with 2min long socket timeouts, which is unacceptable