### PR TITLE
Add moar invalid target checking

### DIFF
--- a/lib/ssh_scan_api/api.rb
+++ b/lib/ssh_scan_api/api.rb
@@ -97,10 +97,14 @@ https://github.com/mozilla/ssh_scan_api/wiki/ssh_scan-Web-API\n"
         socket = {"target" => target, "port" => port}
 
         # Let's stop garbage targets in their tracks
-        if !target.ip_addr? && !target.fqdn?
+        if target.nil? || target.empty?
+          return {"error" => "invalid target"}.to_json
+        elsif target.downcase == "localhost"
+          return {"error" => "invalid target"}.to_json
+        elsif !target.ip_addr? && !target.fqdn?
           return {"error" => "invalid target"}.to_json
         elsif target.ip_addr? && target.start_with?("127")
-          return {"error" => "invalid target"}.to_json 
+          return {"error" => "invalid target"}.to_json
         end
 
         # Check DB to see if we have a recent scans (<= 5 min ago) for this target


### PR DESCRIPTION
We had a couple cases where people where trying various bogus targets and they were causing tasked scans to never complete, which ran up the running status count.  These should just be discarded before they enter queued state to prevent this from happening in the future.