### PR TITLE
Force production environment, which disables stacktraces

### DIFF
--- a/lib/ssh_scan_api/api.rb
+++ b/lib/ssh_scan_api/api.rb
@@ -250,6 +250,7 @@ https://github.com/mozilla/ssh_scan_api/wiki/ssh_scan-Web-API\n"
         set :authenticator, SSHScan::Authenticator.from_config_file(
           options["config_file"]
         )
+        set :environment, :production
         set :allowed_ports, options["allowed_ports"]
         set :protection, false
       end


### PR DESCRIPTION
We had set env to prod for resting env, but not for the official prod env, go figure.