### PR TITLE
Add batch queue for research purposes

### DIFF
--- a/lib/ssh_scan_api/database.rb
+++ b/lib/ssh_scan_api/database.rb
@@ -33,6 +33,10 @@ module SSHScan
       @database.queue_count
     end
 
+    def batch_queue_count
+      @database.batch_queue_count
+    end
+
     def error_count
       @database.error_count
     end
@@ -69,12 +73,20 @@ module SSHScan
       @database.queue_scan(uuid, socket)
     end
 
+    def batch_queue_scan(uuid, socket)
+      @database.batch_queue_scan(uuid, socket)
+    end
+
     def complete_scan(uuid, worker_id, result)
       @database.complete_scan(uuid, worker_id, result)
     end
 
     def error_scan(uuid, worker_id, result)
       @database.error_scan(uuid, worker_id, result)
+    end
+
+    def next_scan_in_batch_queue
+      @database.next_scan_in_batch_queue
     end
 
     def next_scan_in_queue

--- a/lib/ssh_scan_api/database/mongo.rb
+++ b/lib/ssh_scan_api/database/mongo.rb
@@ -35,12 +35,28 @@ module SSHScan
         )
       end
 
+      def batch_queue_scan(uuid, socket)
+        @collection.insert_one(
+          "uuid" => uuid,
+          "target" => socket["target"],
+          "port" => socket["port"].to_i,
+          "status" => "BATCH_QUEUED",
+          "scan" => nil,
+          "queue_time" => Time.now,
+          "worker_id" => nil,
+        )
+      end
+
       def run_count
         @collection.count(status: 'RUNNING')
       end
 
       def queue_count
         @collection.count(status: 'QUEUED')
+      end
+
+      def batch_queue_count
+        @collection.count(status: 'BATCH_QUEUED')
       end
 
       def error_count
@@ -125,7 +141,11 @@ module SSHScan
         return histogram
       end
 
-      def next_scan_in_queue()
+      def next_scan_in_batch_queue
+        @collection.find(status: "BATCH_QUEUED").first
+      end
+
+      def next_scan_in_queue
         @collection.find(status: "QUEUED").first
       end
 

--- a/spec/ssh_scan_api/database/mongodb_spec.rb
+++ b/spec/ssh_scan_api/database/mongodb_spec.rb
@@ -35,6 +35,22 @@ describe SSHScan::DB::MongoDb do
     expect(doc["worker_id"]).to eql(nil)
   end
 
+  it "should #batch_queue_scan in the collection" do
+    uuid = SecureRandom.uuid
+    socket = {"target" => "127.0.0.1", "port" => 1337}
+
+    @mongodb.batch_queue_scan(uuid, socket)
+
+    # Emulate the retrieval process
+    doc = @mongodb.collection.find(:uuid => uuid).first
+
+    expect(doc["_id"]).to be_kind_of(::BSON::ObjectId)
+    expect(doc["uuid"]).to eql(uuid)
+    expect(doc["status"]).to eql("BATCH_QUEUED")
+    expect(doc["scan"]).to eql(nil)
+    expect(doc["worker_id"]).to eql(nil)
+  end
+
   it "should #run_scan in the collection" do
     uuid = SecureRandom.uuid
     socket = {"target" => "127.0.0.1", "port" => 1337}


### PR DESCRIPTION
This allows research scans added to the queue that *ideally* will not affect production UI queue priority