### PR TITLE
Re-add status key to scan results

### DIFF
--- a/lib/ssh_scan_api/api.rb
+++ b/lib/ssh_scan_api/api.rb
@@ -143,7 +143,9 @@ module SSHScan
             when "RUNNNING"
               return {"status" => "RUNNNING"}.to_json
             when "COMPLETED"
-              return scan.raw_scan
+              parsed_scan = JSON.parse(scan.raw_scan)
+              parsed_scan["status"] = "COMPLETED"
+              return parsed_scan.to_json
             else
               return {"status" => "UNKNOWN"}.to_json
             end


### PR DESCRIPTION
Re-add trigger that obs front-end is expecting for scan completion.  This fixes a bug where observatory website driven scans would not appear to complete in the front-end, even though they were completing in the service, just not properly displaying based on expectations here:

https://github.com/mozilla/http-observatory-website/blob/master/js/httpobs-third-party.js#L435-L444

This bug was introduced in the ActiveRecord migration